### PR TITLE
Refactor CI workflow permissions and settings

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -31,10 +31,6 @@ jobs:
     permissions:
       id-token: write
 
-    # Allow the job to request OIDC tokens for Codecov tokenless uploads
-    permissions:
-      id-token: write
-
     env:
       NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
 
@@ -94,9 +90,7 @@ jobs:
                 --collect:"XPlat Code Coverage" \
                 --settings runsettings.xml \
                 --results-directory "TestResults" 2>&1 | tee "TestResults/${filename}.log"
-                --settings runsettings.xml \
-                --settings runsettings.xml \
-                --results-directory "TestResults" 2>&1 | tee "TestResults/${filename}.log"
+
               rc=$?
               set -e
 


### PR DESCRIPTION
Clean up permissions by removing duplicate settings in the CI workflow to streamline the configuration.