### PR TITLE
Refactor GitHub Actions workflow for .NET

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -188,27 +188,22 @@ jobs:
           path: ${{ github.workspace }}/TestResults/**/*.log
 
       - name: Codecov
-        uses: codecov/codecov-action@v5.4.3
+      - uses: actions/checkout@main
+      - uses: codecov/codecov-action@v5.4.3
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
         uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
         id: test-results
-        # When running locally with the 'nektos/act,' the GITHUB_ACTOR is 'nektos/act' and
-        # the runner can't access GitHub's API for local commit SHAs. Skip
-        # publishing test results (which queries commits/pull requests) in
-        # that case to avoid 403/422 API errors.
-        if: always() && github.actor != 'nektos/act'
+        if: always()
         with:
-          # Disable creating GitHub check runs when running locally with 'nektos/act'
-          # (this avoids the "You must authenticate via a GitHub App" 403 error
-          # that happens because 'nektos/act' can't emulate GitHub App authentication).
-          check_run: false
           files: |
-            ${{ github.workspace }}/TestResults/**/*.trx
+            TestResults/**/*.trx
 
       - name: Install GitVersion
         if: github.actor != 'nektos/act'

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -188,7 +188,7 @@ jobs:
           path: ${{ github.workspace }}/TestResults/**/*.log
 
       - name: Codecov
-      - uses: actions/checkout@main
+      - uses: actions/checkout@v4
       - uses: codecov/codecov-action@v5.4.3
 
       - name: Upload test results to Codecov


### PR DESCRIPTION
This pull request updates the `.github/workflows/dotnet.yml` workflow, primarily to improve compatibility and reliability of test result publishing and Codecov integration. The most important changes are grouped below:

**Workflow reliability and compatibility improvements:**

* Added a step to use `actions/checkout@main` before running the Codecov upload step to ensure the repository is checked out for subsequent actions.
* Updated the `Publish Test Results` step to always run regardless of the actor, removing the previous condition that skipped this step when running locally with `nektos/act`.
* Simplified the file path for test results in the `Publish Test Results` step from `${{ github.workspace }}/TestResults/**/*.trx` to `TestResults/**/*.trx` for better compatibility.

**Codecov integration:**

* Added the `token` input to the `codecov/test-results-action` step, using `${{ secrets.CODECOV_TOKEN }}` for authentication.Updated the workflow to include actions checkout and modified conditions for publishing test results.