### PR TITLE
Fix indentation for Codecov action in workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -188,8 +188,7 @@ jobs:
           path: ${{ github.workspace }}/TestResults/**/*.log
 
       - name: Codecov
-      - uses: actions/checkout@v4
-      - uses: codecov/codecov-action@v5.4.3
+        uses: codecov/codecov-action@v5.4.3
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}


### PR DESCRIPTION
This pull request makes a small adjustment to the Codecov workflow in `.github/workflows/dotnet.yml` by removing a redundant `actions/checkout@v4` step before running the Codecov upload action.

* Removed unnecessary `actions/checkout@v4` usage from the Codecov step in the workflow file, simplifying the job sequence.