### PR TITLE
Refactor test by removing unnecessary exception handling

### DIFF
--- a/Tests/Web.Tests.Unit/Components/Features/Articles/ArticleList/ListTests.cs
+++ b/Tests/Web.Tests.Unit/Components/Features/Articles/ArticleList/ListTests.cs
@@ -239,11 +239,6 @@ public class ListTests : BunitContext
 
 		var initial = nav.Uri;
 
-		catch (InvalidOperationException)
-		{
-			// expected for disabled button in some bUnit configurations
-		}
-
 		// Assert - navigation should not have changed
 		nav.Uri.Should().Be(initial);
 	}


### PR DESCRIPTION
Simplify the `Disabled_Edit_Button_Does_Not_Navigate` test by eliminating redundant exception handling for expected behavior.