### PR TITLE
Update CreateCategory handler to accept nullable CategoryDto and add unit tests

### DIFF
--- a/SRC/Web/Components/Features/Categories/CategoryCreate/CreateCategory.cs
+++ b/SRC/Web/Components/Features/Categories/CategoryCreate/CreateCategory.cs
@@ -16,7 +16,7 @@ public static class CreateCategory
 {
 	public interface ICreateCategoryHandler
 	{
-		Task<Result> HandleAsync(CategoryDto request);
+		Task<Result> HandleAsync(CategoryDto? request);
 	}
 
 	/// <summary>
@@ -44,13 +44,13 @@ public static class CreateCategory
 		/// </summary>
 		/// <param name="request">The category DTO.</param>
 		/// <returns>A <see cref="Result"/> indicating success or failure.</returns>
-		public async Task<Result> HandleAsync(CategoryDto request)
+		public async Task<Result> HandleAsync(CategoryDto? request)
 		{
 			try
 			{
 				var category = new Category
 				{
-					CategoryName = request.CategoryName,
+					CategoryName = request!.CategoryName,
 				};
 
 				await _context.Categories.InsertOneAsync(category);
@@ -61,7 +61,7 @@ public static class CreateCategory
 			}
 			catch (Exception ex)
 			{
-				_logger.LogError(ex, "Failed to create category: {CategoryName}", request.CategoryName);
+				_logger.LogError(ex, "Failed to create category: {CategoryName}", request?.CategoryName ?? string.Empty);
 				return Result.Fail(ex.Message);
 			}
 		}

--- a/Tests/Web.Tests.Unit/Components/Features/Articles/ArticlesCreate/CreateArticleHandlerTests.cs
+++ b/Tests/Web.Tests.Unit/Components/Features/Articles/ArticlesCreate/CreateArticleHandlerTests.cs
@@ -35,7 +35,8 @@ public class CreateArticleHandlerTests
 		// Assert
 		result.Success.Should().BeTrue();
 		// Verify an Article was inserted, and PublishedOn was set (not default)
-		_ = _fixture.ArticlesCollection.Received(1).InsertOneAsync(Arg.Is<Article>(a => a.Title == dto.Title && a.Introduction == dto.Introduction && a.PublishedOn != null), Arg.Any<InsertOneOptions>(), Arg.Any<CancellationToken>());
+		_ = _fixture.ArticlesCollection
+			.Received(1).InsertOneAsync(Arg.Is<Article>(a => a.Title == dto.Title && a.Introduction == dto.Introduction && a.PublishedOn != null), Arg.Any<InsertOneOptions>(), Arg.Any<CancellationToken>());
 	}
 
 	[Fact]

--- a/Tests/Web.Tests.Unit/Components/Features/Categories/CategoryCreate/CreateCategoryHandlerTests.cs
+++ b/Tests/Web.Tests.Unit/Components/Features/Categories/CategoryCreate/CreateCategoryHandlerTests.cs
@@ -1,0 +1,103 @@
+// =======================================================
+// Copyright (c) 2025. All rights reserved.
+// File Name :     CreateCategoryHandlerTests.cs
+// Company :       mpaulosky
+// Author :        Copilot
+// Solution Name : BlazorBlogApplication
+// Project Name :  Web.Tests.Unit
+// =======================================================
+
+using Web.Components.Features.Categories.CategoryCreate;
+using Web.Data.Entities;
+using Web.Components.Features.Categories; // for CategoryTestFixture
+using Microsoft.Extensions.Logging;
+
+namespace Web.Components.Features.Categories.CategoryCreate;
+
+[ExcludeFromCodeCoverage]
+[TestSubject(typeof(CreateCategory.Handler))]
+public class CreateCategoryHandlerTests
+{
+	private readonly CategoryTestFixture _fixture = new CategoryTestFixture();
+
+	[Fact]
+	public async Task HandleAsync_InsertsCategoryAndReturnsOk()
+	{
+		// Arrange - ensure insert returns completed task
+		_fixture.CategoriesCollection
+			.InsertOneAsync(Arg.Any<Category>(), Arg.Any<InsertOneOptions>(), Arg.Any<CancellationToken>())
+			.Returns(Task.CompletedTask);
+
+		var logger = Substitute.For<ILogger<CreateCategory.Handler>>();
+		var handler = new CreateCategory.Handler(_fixture.BlogContext, logger);
+
+		var dto = new CategoryDto { CategoryName = "Test Cat" };
+
+		// Act
+		var result = await handler.HandleAsync(dto);
+
+		// Assert
+		result.Success.Should().BeTrue();
+		_ = _fixture.CategoriesCollection.Received(1)
+			.InsertOneAsync(Arg.Is<Category>(c => c.CategoryName == dto.CategoryName), Arg.Any<InsertOneOptions>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task HandleAsync_ReturnsFail_WhenInsertThrows()
+	{
+		// Arrange - make the collection throw on insert
+		_fixture.CategoriesCollection.When(c => c.InsertOneAsync(Arg.Any<Category>(), Arg.Any<InsertOneOptions>(), Arg.Any<CancellationToken>()))
+			.Do(_ => throw new InvalidOperationException("DB error"));
+
+		var logger = Substitute.For<ILogger<CreateCategory.Handler>>();
+		var handler = new CreateCategory.Handler(_fixture.BlogContext, logger);
+
+		var dto = new CategoryDto { CategoryName = "T" };
+
+		// Act
+		var result = await handler.HandleAsync(dto);
+
+		// Assert
+		result.Failure.Should().BeTrue();
+		result.Error.Should().Contain("DB error");
+		logger.Received(1).Log(LogLevel.Error, Arg.Any<EventId>(), Arg.Any<object>(), Arg.Any<Exception?>(), Arg.Any<Func<object, Exception?, string>>());
+	}
+
+	[Fact]
+	public async Task HandleAsync_NullRequest_ReturnsFail()
+	{
+		// Arrange
+		_fixture.CategoriesCollection.InsertOneAsync(Arg.Any<Category>(), Arg.Any<InsertOneOptions>(), Arg.Any<CancellationToken>()).Returns(Task.CompletedTask);
+		var logger = Substitute.For<ILogger<CreateCategory.Handler>>();
+		var handler = new CreateCategory.Handler(_fixture.BlogContext, logger);
+
+		// Act
+		var result = await handler.HandleAsync(null!);
+
+		// Assert - should return failure and include exception information
+
+		result.Failure.Should().BeTrue();
+		result.Error.Should().NotBeNullOrEmpty();
+	}
+
+	[Fact]
+	public async Task HandleAsync_EmptyName_InsertsEmptyAndReturnsOk()
+	{
+		// Arrange - ensure insert returns completed task
+		_fixture.CategoriesCollection.InsertOneAsync(Arg.Any<Category>(), Arg.Any<InsertOneOptions>(), Arg.Any<CancellationToken>())
+			.Returns(Task.CompletedTask);
+
+		var logger = Substitute.For<ILogger<CreateCategory.Handler>>();
+		var handler = new CreateCategory.Handler(_fixture.BlogContext, logger);
+		var dto = new CategoryDto { CategoryName = string.Empty };
+
+		// Act
+		var result = await handler.HandleAsync(dto);
+
+		// Assert - current handler will accept empty names; ensure insert called and success returned
+		result.Success.Should().BeTrue();
+		_ = _fixture.CategoriesCollection.Received(1).InsertOneAsync(Arg.Is<Category>(c => c.CategoryName == dto.CategoryName), Arg.Any<InsertOneOptions>(), Arg.Any<CancellationToken>());
+
+	}
+
+}

--- a/Tests/Web.Tests.Unit/Components/Features/Categories/CategoryTestFixture.cs
+++ b/Tests/Web.Tests.Unit/Components/Features/Categories/CategoryTestFixture.cs
@@ -27,11 +27,15 @@ public class CategoryTestFixture : IAsyncDisposable
 
 	private IMongoDatabase MongoDatabase { get; }
 
-	private IMongoCollection<Category> CategoriesCollection { get; }
+	// Expose the collection so handler tests can configure InsertOneAsync behavior
+	public IMongoCollection<Category> CategoriesCollection { get; }
 
-	private MyBlogContext BlogContext { get; }
+	private MyBlogContext _blogContext;
 
-	private ILogger<Handler> Logger { get; }
+	// Expose the IMyBlogContext for tests similar to ArticlesTestFixture
+	public IMyBlogContext BlogContext { get; private set; }
+
+	public ILogger<Handler> Logger { get; }
 
 	public CategoryTestFixture()
 	{
@@ -40,7 +44,8 @@ public class CategoryTestFixture : IAsyncDisposable
 		CategoriesCollection = Substitute.For<IMongoCollection<Category>>();
 		MongoClient.GetDatabase(Arg.Any<string>()).Returns(MongoDatabase);
 		MongoDatabase.GetCollection<Category>(Arg.Any<string>()).Returns(CategoriesCollection);
-		BlogContext = new MyBlogContext(MongoClient);
+		_blogContext = new MyBlogContext(MongoClient);
+		BlogContext = _blogContext;
 		Logger = Substitute.For<ILogger<Handler>>();
 	}
 


### PR DESCRIPTION
Modify the CreateCategory handler to handle nullable CategoryDto inputs and implement corresponding unit tests to ensure correct behavior for various scenarios, including null and empty category names.