### PR TITLE
fix(tests): standardize test results directory naming and update test…

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -60,8 +60,8 @@ jobs:
       - name: Run all tests in all test projects
         id: run-tests
         run: |
-          # Ensure repository-level TestResults exists
-          mkdir -p "TestResults"
+          # Ensure repository-level test-results exists
+          mkdir -p "test-results"
           timestamp=$(date +%s)
 
           set -o pipefail
@@ -69,15 +69,16 @@ jobs:
           while IFS= read -r proj; do
             if grep -q "<IsTestProject>true</IsTestProject>" "$proj" 2>/dev/null; then
               name=$(basename "$proj" .csproj)
-              echo "Running tests for: $proj -> TestResults/${name}.trx (logs -> TestResults/${name}.coverage.log)"
+              echo "Running tests for: $proj -> test-results/${name}.trx (logs -> test-results/${name}.coverage.log)"
               set +e
               # Run tests and collect XPlat Code Coverage; quoting is safe for bash
               dotnet test "$proj" \
                 --no-build --no-restore \
                 --collect:"XPlat Code Coverage" \
                 --logger "trx;LogFileName=${name}.trx" \
+                --logger "junit;LogFileName=${name}.coverage.opencover.xml" \
                 --settings runsettings.xml \
-                --results-directory "TestResults" 2>&1 | tee "TestResults/${name}.log"
+                --results-directory "test-results" 2>&1 | tee "test-results/${name}.log"
               rc=$?
               set -e
 
@@ -97,21 +98,19 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Solution-Test-Results
-          path: TestResults
+          path: test-results
 
-      - name: Upload TestResults (fallback for debugging)
-        if: ${{ steps.check-test-results.outputs.found_trx != 'true' }}
+      - name: Upload test-results (fallback for debugging)
         uses: actions/upload-artifact@v4
         with:
-          name: TestResults-Debug
-          path: TestResults/**
+          name: test-results-Debug
+          path: test-results/**
 
       - name: Upload Test Logs
-        if: ${{ steps.check-test-results.outputs.found_logs == 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: Test-Logs
-          path: ${{ github.workspace }}/TestResults/**/*.log
+          path: ${{ github.workspace }}/test-results/**/*.log
 
       - name: Codecov
         uses: codecov/codecov-action@v5.4.3
@@ -121,7 +120,7 @@ jobs:
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: TestResults/**/*.xml
+          files: test-results/**/*.xml
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action@v2
@@ -129,7 +128,9 @@ jobs:
         if: always()
         with:
           files: |
-            TestResults/**/*.trx
+            test-results/**/*.trx
+            test-results/**/*.xml
+            test-results/**/*.json
 
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v4.1.0

--- a/Tests/Web.Tests.Unit/Components/Features/Articles/ArticleDetails/DetailsTests.cs
+++ b/Tests/Web.Tests.Unit/Components/Features/Articles/ArticleDetails/DetailsTests.cs
@@ -8,6 +8,7 @@
 // =======================================================
 
 using static Web.Components.Features.Articles.ArticleDetails.GetArticle;
+using Web.Components.Features.Articles.ArticleDetails;
 
 namespace Web.Components.Features.Articles.ArticleDetails;
 

--- a/Tests/Web.Tests.Unit/Components/Features/Articles/ArticleDetails/UnitTests.slnf
+++ b/Tests/Web.Tests.Unit/Components/Features/Articles/ArticleDetails/UnitTests.slnf
@@ -1,0 +1,10 @@
+{
+  "solution": {
+    "path": "BlazorBlogApplication.sln",
+    "projects": [
+      "Tests\\Web.Tests.Unit\\Web.Tests.Unit.csproj",
+			"Tests\\Architecture.Tests.Unit\\Architecture.Tests.Unit.csproj,
+			"Tests\\Shared.Tests.Unit\\Shared.Tests.Unit.csproj
+    ]
+  }
+}


### PR DESCRIPTION
This pull request focuses on standardizing test artifact naming conventions and improving test result handling in the CI workflow, along with minor updates to test project configuration. The most impactful changes are in the `.github/workflows/dotnet.yml` file, where the directory name for test results is unified and additional result formats are supported. There are also minor code organization improvements and the addition of a solution filter for unit tests.

**CI workflow improvements:**

* Renamed the test results directory from `TestResults` to `test-results` throughout the workflow for consistency, including all references in artifact upload, logging, and result publishing steps. [[1]](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344L63-R81) [[2]](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344L100-R113) [[3]](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344L124-R133)
* Added support for generating JUnit-style coverage XML files during test execution by including the `--logger "junit;LogFileName=${name}.coverage.opencover.xml"` option in the test run command.
* Updated the list of published test result files to include `.xml` and `.json` formats in addition to `.trx` files for broader compatibility with reporting tools.

**Test project configuration:**

* Added a missing using directive for `Web.Components.Features.Articles.ArticleDetails` in `DetailsTests.cs` to improve code clarity and maintainability.
* Introduced a new solution filter file `UnitTests.slnf` to simplify running only unit tests across multiple projects.… project references