### PR TITLE
fix(workflow): remove unnecessary test result file types from upload …

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -129,8 +129,6 @@ jobs:
         with:
           files: |
             test-results/**/*.trx
-            test-results/**/*.xml
-            test-results/**/*.json
 
       - name: Install GitVersion
         uses: gittools/actions/gitversion/setup@v4.1.0

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -77,7 +77,6 @@ jobs:
                 --collect:"XPlat Code Coverage" \
                 --logger "trx;LogFileName=${name}.trx" \
                 --logger "junit;LogFileName=${name}.coverage.opencover.xml" \
-                --settings runsettings.xml \
                 --results-directory "test-results" 2>&1 | tee "test-results/${name}.log"
               rc=$?
               set -e
@@ -99,12 +98,6 @@ jobs:
         with:
           name: Solution-Test-Results
           path: test-results
-
-      - name: Upload test-results (fallback for debugging)
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-results-Debug
-          path: test-results/**
 
       - name: Upload Test Logs
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
…step
This pull request makes some targeted updates to the `.github/workflows/dotnet.yml` workflow configuration, mainly focused on simplifying test result handling and artifact uploads. The changes remove unused or redundant steps and settings to streamline the workflow.

**Workflow simplification and cleanup:**

* Removed the `--settings runsettings.xml` option from the test execution command, which eliminates dependency on a custom run settings file during test runs.
* Deleted the fallback step for uploading test results with the name `test-results-Debug`, reducing unnecessary artifact uploads for debugging.

**Artifact upload adjustments:**

* Limited the files uploaded for test logs to only `.trx` files, excluding `.xml` and `.json` files to reduce artifact size and focus on essential test output.