### PR TITLE
test(Web): correct date format in Details component tests

### DIFF
--- a/Tests/Web.Tests.Unit/Components/Features/Categories/CategoryDetails/DetailsTests.cs
+++ b/Tests/Web.Tests.Unit/Components/Features/Categories/CategoryDetails/DetailsTests.cs
@@ -61,8 +61,8 @@ public class DetailsTests : BunitContext
 
 		// Assert
 		cut.Markup.Should().Contain(categoryDto.CategoryName);
-		cut.Markup.Should().Contain("Created On: 01/1/2025");
-		cut.Markup.Should().Contain("Modified On: 01/1/2025");
+		cut.Markup.Should().Contain("Created On: 01/01/2025");
+		cut.Markup.Should().Contain("Modified On: 01/01/2025");
 		cut.Find("button.btn-secondary").Should().NotBeNull();
 		//not admin the edit button should be disabled
 		cut.Find("button.btn-secondary").HasAttribute("disabled").Should().BeTrue();
@@ -87,8 +87,8 @@ public class DetailsTests : BunitContext
 
 		// Assert
 		cut.Markup.Should().Contain(categoryDto.CategoryName);
-		cut.Markup.Should().Contain("Created On: 01/1/2025");
-		cut.Markup.Should().Contain("Modified On: 01/1/2025");
+		cut.Markup.Should().Contain("Created On: 01/01/2025");
+		cut.Markup.Should().Contain("Modified On: 01/01/2025");
 		cut.Find("button.btn-secondary").Should().NotBeNull();
 		//not admin the edit button should be disabled
 		cut.Find("button.btn-secondary").HasAttribute("disabled").Should().BeFalse();


### PR DESCRIPTION
- Update date format from "01/1/2025" to "01/01/2025" for consistency.
- Ensure both created and modified date displays are corrected.